### PR TITLE
Update demo to animate

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -2,7 +2,11 @@ div.header {
   position: relative;
 }
 
-div.header img {
+/* When we animate the element, it will get pulled out of its original
+place in the DOM. So any styles that we want to persist need to be
+targeted directly at the element itself, without depending on
+context. */
+.header-img {
   width: 50px;
   height: auto;
   padding: 1em;
@@ -19,12 +23,19 @@ div.container {
   position: relative
 }
 
-div.container img {
+.splash-img {
   padding: 1em;
   position: absolute;
   top: 50%;
   left: 50%;
   margin-right: -50%;
-  transform: translate(-50%, -50%)
+
+  /* The fly-to animation uses translate, and doesn't know how to
+     account for an element that already has a preexisting
+     translate. */
+  /* transform: translate(-50%, -50%) */
 }
 
+#animation > div {
+    border: 1px solid blue;
+}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,6 +1,6 @@
 <div class="header">
   {{#link-to 'splash' use="fly-to"}}
-    <img src="/images/logo.png" alt="4 Legs Software">
+    <img class="header-img" src="/images/logo.png" alt="4 Legs Software">
   {{/link-to}}
   <h4> 4 Legs Software
     <p>@robpark</p></h4>

--- a/app/templates/splash.hbs
+++ b/app/templates/splash.hbs
@@ -1,5 +1,5 @@
 <div class="container">
   {{#link-to 'index'}}
-    <img src="/images/logo.png" alt="4 Legs Software">
+    <img class="splash-img" src="/images/logo.png" alt="4 Legs Software">
   {{/link-to}}
 </div>

--- a/app/transition.js
+++ b/app/transition.js
@@ -1,7 +1,0 @@
-export default function() {
-  this.transition(
-    this.fromRoute('index'),
-    this.toRoute('splash'),
-    this.use('fly-to')
-  );
-}

--- a/app/transitions.js
+++ b/app/transitions.js
@@ -1,0 +1,14 @@
+export default function() {
+  this.transition(
+    this.fromRoute('index'),
+    this.toRoute('splash'),
+    this.use('explode', {
+      pick: 'img',
+      use: 'fly-to'
+    }),
+    this.reverse('explode', {
+      pick: 'img',
+      use: 'fly-to'
+    })
+  );
+}


### PR DESCRIPTION
The main issue was that the file `app/transitions.js` was misnamed.

Once that is fixed a few other problems came up. `fly-to` by itself in this case won't have any visible effect, because it is trying to make the original content of the `liquid-outlet` fly to the new content of the `liquid-outlet`, which are both already in the same place on screen. The solution to this is to use `explode` to pull out just the thing we want to animate (presumably the image).

The next issue that came up was that the image was jumping at the start and end of animation. This is because it has padding & margins that only apply when it is inside a particular parent element, and during animation it is not still inside that parent element. So I changed the styles to target the image's class directly.

Finally, the fly-to animation uses `transform` to do the flying, and doesn't know how to account for an element that already has a `transform` in its final end state.  For that I filed https://github.com/ef4/liquid-fire/issues/248.

Also, just in case you try to slow down this demo animation, you will probably notice that you'll also want to slow down the growth speed of the container, which is currently not possible due to https://github.com/ef4/liquid-fire/issues/246. 